### PR TITLE
Use media stream on DOM objects directly

### DIFF
--- a/client/webrtc.js
+++ b/client/webrtc.js
@@ -84,7 +84,7 @@ function pageReady() {
 
 function getUserMediaSuccess(stream) {
     localStream = stream;
-    localVideo.src = window.URL.createObjectURL(stream);
+    localVideo.srcObject = stream;
 }
 
 function gotRemoteStream(event, id) {
@@ -94,7 +94,7 @@ function gotRemoteStream(event, id) {
         div    = document.createElement('div')
 
     video.setAttribute('data-socket', id);
-    video.src         = window.URL.createObjectURL(event.stream);
+    video.srcObject   = event.stream;
     video.autoplay    = true; 
     video.muted       = true;
     video.playsinline = true;


### PR DESCRIPTION
Some browsers do not support 'window.URL.createObjectURL' as the code was expecting.