### PR TITLE
fix: erase chaning comma after jade

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "dependencies": {
     "express": "2.5.8",
-    "jade": ">= 0.0.1",
+    "jade": ">= 0.0.1"
   },
   "devDependencies": {
     "http": "0.0.0",


### PR DESCRIPTION
I erased the chaining comma after jade version info to make this file real JSON